### PR TITLE
use etcher instructions

### DIFF
--- a/vab820-quad.coffee
+++ b/vab820-quad.coffee
@@ -5,6 +5,13 @@ BOARD_SHUTDOWN_VIA = 'The device is performing a shutdown. Please wait until the
 SET_JUMPER_SD = 'Set J11 (just next to the micro SD card slot) to position 2-3 (the position furthest away from the edge of the board) and then power on the board.'
 SET_JUMPER_EMMC = 'Set J11 (just next to the micro SD card slot) to position 1-2 (the position closest to the edge of the board).'
 
+postProvisioningInstructions = [
+	BOARD_SHUTDOWN_VIA
+	instructions.REMOVE_INSTALL_MEDIA
+	SET_JUMPER_EMMC
+	instructions.BOARD_REPOWER
+]
+
 module.exports =
 	slug: 'via-vab820-quad'
 	aliases: [ 'vab820-quad' ]
@@ -13,47 +20,14 @@ module.exports =
 	state: 'released'
 
 	stateInstructions:
-		postProvisioning: [
-			BOARD_SHUTDOWN_VIA
-			instructions.REMOVE_INSTALL_MEDIA
-			SET_JUMPER_EMMC
-			instructions.BOARD_REPOWER
-		]
+		postProvisioning: postProvisioningInstructions
 
-	instructions:
-		windows: [
-			instructions.WINDOWS_DISK_IMAGER_SD
-			instructions.EJECT_SD
-			instructions.FLASHER_WARNING
-			SET_JUMPER_SD
-			BOARD_SHUTDOWN_VIA
-			instructions.REMOVE_INSTALL_MEDIA
-			SET_JUMPER_EMMC
-			instructions.BOARD_REPOWER
-		]
-		osx: [
-			instructions.OSX_PLUG_SD
-			instructions.OSX_UNMOUNT_SD
-			instructions.DD_BURN_IMAGE_SD
-			instructions.EJECT_SD
-			instructions.FLASHER_WARNING
-			SET_JUMPER_SD
-			BOARD_SHUTDOWN_VIA
-			instructions.REMOVE_INSTALL_MEDIA
-			SET_JUMPER_EMMC
-			instructions.BOARD_REPOWER
-		]
-		linux: [
-			instructions.LINUX_DF_SD
-			instructions.DD_BURN_IMAGE_SD
-			instructions.EJECT_SD
-			instructions.FLASHER_WARNING
-			SET_JUMPER_SD
-			BOARD_SHUTDOWN_VIA
-			instructions.REMOVE_INSTALL_MEDIA
-			SET_JUMPER_EMMC
-			instructions.BOARD_REPOWER
-		]
+	instructions: [
+		instructions.ETCHER_SD
+		instructions.EJECT_SD
+		instructions.FLASHER_WARNING
+		SET_JUMPER_SD
+	].concat(postProvisioningInstructions)
 
 	gettingStartedLink:
 		windows: 'http://docs.resin.io/#/pages/installing/gettingStarted-VIA-VAB820.md#windows'


### PR DESCRIPTION
This makes the instructions use Etcher as primary image burning software.

To make it work: (from @emirotin) 
1. approve and merge resin-io/resin-device-types#7
2. update the resin-device-types submodule in this branch and update this PR
3. test how the JSON file is built (I've tested it myself by checking out the corresponding branch in a submodule)
4. approve and merge this PR
5. follow the standard procedure to release this device type and get it to img-maker
